### PR TITLE
fix: Messages undefined error on results.

### DIFF
--- a/xo-server/src/server.ts
+++ b/xo-server/src/server.ts
@@ -186,14 +186,16 @@ class Linter {
 
 				// Clean previously computed code actions.
 				delete this.codeActions[uri];
+				const results = report.results;
+				if(results.length && results[0].hasOwnProperty('messages')) {
+					const diagnostics: Diagnostic[] = report.results[0].messages.map((problem: any) => {
+						const diagnostic = makeDiagnostic(problem);
+						this.recordCodeAction(document, diagnostic, problem);
+						return diagnostic;
+					});
 
-				const diagnostics: Diagnostic[] = report.results[0].messages.map((problem: any) => {
-					const diagnostic = makeDiagnostic(problem);
-					this.recordCodeAction(document, diagnostic, problem);
-					return diagnostic;
-				});
-
-				this.connection.sendDiagnostics({uri, diagnostics});
+					this.connection.sendDiagnostics({uri, diagnostics});
+				}
 			});
 	}
 


### PR DESCRIPTION
This was fixed in the Atom linter as well ( see https://github.com/sindresorhus/xo/issues/210 ). I tested it on my local install and doing a quick property check solves the issue.

Here's the commit for the fix they put on the atom-linter-xo ( https://github.com/sindresorhus/atom-linter-xo/commit/2e762580c6ead8ae44a153cc6c27be542dde3b25 ). The expansions are nice but I'm not used to TypeScript so I kept it simple. 

To reproduce the issue just make a folder with a dot prefix in your project (e.g. `.storybook`). VSCode start showing the "messages" error quite often. 