### PR TITLE
Fix cannot find module 'xo' issue

### DIFF
--- a/xo-server/src/server.ts
+++ b/xo-server/src/server.ts
@@ -143,7 +143,7 @@ class Linter {
 				if (this.package.isDependency('xo')) {
 					throw new ResponseError<InitializeError>(99, 'Failed to load XO library. Make sure XO is installed in your workspace folder using \'npm install xo\' and then press Retry.', {retry: true});
 				}
-				throw err;
+				return result;
 			});
 	}
 


### PR DESCRIPTION
An error will be thrown if xo module cannot be found in a javascript project.
No need to panic because clearly xo should just be disabled.