### PR TITLE
improve check for file path in document validation

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -189,11 +189,12 @@ class Linter {
 			.then(() => {
 				const uri = document.uri;
 				const fsPath = Files.uriToFilePath(uri);
-				const contents = document.getText();
 
-				if (fsPath === null) {
+				if (!fsPath) {
 					return;
 				}
+
+				const contents = document.getText();
 
 				const options = this.options;
 				options.cwd = this.workspaceRoot;


### PR DESCRIPTION
This fixes issue #49 where an error would be thrown about the file path being `undefined` rather than a string when opening a js file in the git diff view. In b6ef79727b84bd4718d944a42450b5741a073622, a fix was introduced for this behavior (see #20), however the API of `Files.uriToFilePath()` must have changed to return `undefined` instead of `null` now.