### PR TITLE
Unignore semver from client dependencies

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@
 **/tsconfig.json
 **/tsconfig.base.json
 client/node_modules/**
+!client/node_modules/semver/**
 !client/node_modules/vscode-jsonrpc/**
 !client/node_modules/vscode-languageclient/**
 !client/node_modules/vscode-languageserver-protocol/**


### PR DESCRIPTION
`yarn --production` in `client` yields

```
semver
vscode-jsonrpc
vscode-languageclient
vscode-languageserver-protocol
vscode-languageserver-types
```

This unignores `semver` and makes the extension work again.

Fix #55

cc @SamVerschueren 