### PR TITLE
Update the minimal vscode engine version to 1.30.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "vscode": "^1.26.0"
+    "vscode": "^1.30.0"
   },
   "scripts": {
     "update-vscode": "node ./node_modules/vscode/bin/install",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"Linters"
 	],
 	"engines": {
-		"vscode": "^1.22.0"
+		"vscode": "^1.30.0"
 	},
 	"activationEvents": [
 		"onLanguage:javascript",


### PR DESCRIPTION
Fixes the build – the code depends on `Declaration` and `LocationLink` types introduced in 1.30.0.