### PR TITLE
Update the `documentSelector` format

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,7 +24,16 @@ export function activate(context: ExtensionContext) {
 	};
 
 	const clientOptions: LanguageClientOptions = {
-		documentSelector: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'],
+		documentSelector: [
+			{language: 'javascript', scheme: 'file'},
+			{language: 'javascript', scheme: 'untitled'},
+			{language: 'javascriptreact', scheme: 'file'},
+			{language: 'javascriptreact', scheme: 'untitled'},
+			{language: 'typescript', scheme: 'file'},
+			{language: 'typescript', scheme: 'untitled'},
+			{language: 'typescriptreact', scheme: 'file'},
+			{language: 'typescriptreact', scheme: 'untitled'},
+		],
 		synchronize: {
 			configurationSection: 'xo',
 			fileEvents: [

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: ExtensionContext) {
 			{language: 'typescript', scheme: 'file'},
 			{language: 'typescript', scheme: 'untitled'},
 			{language: 'typescriptreact', scheme: 'file'},
-			{language: 'typescriptreact', scheme: 'untitled'},
+			{language: 'typescriptreact', scheme: 'untitled'}
 		],
 		synchronize: {
 			configurationSection: 'xo',


### PR DESCRIPTION
Fixes warning: “Extension 'samverschueren.linter-xo' uses a document selector without scheme. Learn more about this: https://go.microsoft.com/fwlink/?linkid=872305”