### PR TITLE
Add documentation for format on save

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ You can enable the formatter integration to use `xo --fix` as formatter. Require
 }
 ```
 
-To format files on save you can enable format on save and the default formatter.
+To format files on save you can enable format on save and set the default formatter to this plugin.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,17 @@ You can enable the formatter integration to use `xo --fix` as formatter. Require
 }
 ```
 
+To format files on save you can enable format on save and the default formatter.
+
+```json
+{
+	"xo.enable": true,
+	"xo.format.enable": true,
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "samverschueren.linter-xo",
+}
+```
+
 ## License
 
 MIT © [Sam Verschueren](http://github.com/SamVerschueren)


### PR DESCRIPTION
Right now the readme has information on how to enable xo and format with it. This doesn't format on save as mentioned in  https://github.com/SamVerschueren/vscode-linter-xo/issues/80. This documentation adds a simple configuration to format on save.

My assumption is that best case people add a key binding to fix with xo and worst case they use another linter with  autosave.

I was thinking about replacing the previous section but wasn't entirely sure that would be the best approach.