### PR TITLE
Add "overrideSeverity" setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,17 @@
 					"default": false,
 					"description": "Enable 'xo --fix' as formatter"
 				},
+				"xo.overrideSeverity": {
+					"type": "string",
+					"default": "off",
+					"enum": [
+						"off",
+						"info",
+						"warn",
+						"error"
+					],
+					"description": "Override the severity of found issues."
+				},
 				"xo.trace.server": {
 					"scope": "window",
 					"type": "string",

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,15 @@ You can enable the formatter integration to use `xo --fix` as formatter. Require
 }
 ```
 
+You can override the severity of found issues, e.g. to make them stand out less than TypeScript errors.
+
+```json
+{
+	"xo.enable": true,
+	"xo.overrideSeverity": "info"
+}
+```
+
 ## License
 
 MIT © [Sam Verschueren](http://github.com/SamVerschueren)

--- a/server/server.js
+++ b/server/server.js
@@ -94,6 +94,9 @@ class Linter {
 		this.connection.onDidChangeConfiguration((params) => {
 			const {settings} = params;
 			this.options = settings.xo ? settings.xo.options || {} : {};
+			this.overrideSeverity = settings.xo
+				? settings.xo.overrideSeverity || undefined
+				: undefined;
 			this.validateMany(this.documents.all());
 		});
 
@@ -222,6 +225,16 @@ class Linter {
 
 		const diagnostics = results[0].messages.map((problem) => {
 			const diagnostic = utils.makeDiagnostic(problem);
+			if (this.overrideSeverity) {
+				const mapSeverity = {
+					off: diagnostic.severity,
+					info: node.DiagnosticSeverity.Information,
+					warn: node.DiagnosticSeverity.Warning,
+					error: node.DiagnosticSeverity.Error
+				};
+				diagnostic.severity = mapSeverity[this.overrideSeverity];
+			}
+
 			this.recordCodeAction(document, diagnostic, problem);
 			return diagnostic;
 		});


### PR DESCRIPTION
```
"xo.overrideSeverity": "info"
```
behaves like [vscode-eslint's](https://github.com/microsoft/vscode-eslint#version-2120)
```
"eslint.rules.customizations": [{
  "rule": "*",
  "severity": "info"
}],
```

<br><br>
(made a vsix package here https://github.com/lukaw3d/vscode-linter-xo/releases/tag/2.3.3-overrideSeverity)